### PR TITLE
Home-manager preview links formatted by OSC 8 escape sequences

### DIFF
--- a/nixfzf
+++ b/nixfzf
@@ -76,7 +76,7 @@ command -v jq >/dev/null 2>&1 || command -v bat >/dev/null 2>&1 || {
 	printArg() {
 		view=$(cat $XDG_CACHE_HOME/hm-options \
 			| processor ".[] | select(.title==\"$1\")" \
-			| sed 's/\[\([^]]*\)\](\(.*\))/\1\: \\e[4m\2\\e[0m/g' \
+			| sed 's/\[\([^]]*\)\](\(.*\))/\\033]8;;\2\\033\\\\ \\e[4m\1\\e[0m \\033]8;;\\033\\\\/g' \
 			| bat --language=yaml --style=numbers --color=always)
 		echo -e "$view"
 	}


### PR DESCRIPTION
Cannot be merged until this feature is supported by fzf.

Blocking issue: https://github.com/junegunn/fzf/issues/2165